### PR TITLE
macOS: run as menu bar accessory (hide Dock icon)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,6 +123,10 @@ pub fn run() {
                 "KimaiTray v{} starting",
                 app.config().version.as_deref().unwrap_or("unknown")
             );
+            // Run as a menu bar accessory on macOS: no Dock icon, only the
+            // system tray (menu bar) presence. Windows/Linux are unaffected.
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             // Must run before tray/shortcuts read the store.
             migrate_legacy_data(app.handle());
             tray::create_tray(app.handle())?;


### PR DESCRIPTION
Set the activation policy to Accessory on macOS so the app lives only in the menu bar (system tray) and no longer shows a Dock icon, matching the expected behaviour of a tray companion app. Windows and Linux are unaffected via #[cfg(target_os = "macos")].