### PR TITLE
fix: let focus timer area grow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -55,9 +55,7 @@
   --focus-timer-height: clamp(88px, 16vh, 112px);
   display: flex;
   flex-direction: column;
-  height: var(--focus-timer-height);
   min-height: var(--focus-timer-height);
-  max-height: var(--focus-timer-height);
 }
 
 html, body, #root {


### PR DESCRIPTION
## Summary
- lets the Focus layout timer area expand beyond its preferred height when content needs more room
- keeps the existing minimum Focus timer height so the layout still has a stable baseline
- avoids forcing the timer area into a fixed height that can conflict with scrollable paused timer content
- fixes the clipped Focus layout state shown in the attached screenshot

<img width="368" height="225" alt="image" src="https://github.com/user-attachments/assets/c1cb0c36-7089-4db0-bd1b-190ef813532e" />

## Verification
- git diff --check