### PR TITLE
fix: Wayland tray icons / AppIndicator middle-click activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ sudo apt install xprintidle
 #### Wayland AppIndicator
 
 - Tauri does not expose direct left/right clicks on tray icons. Therefore, left/right click both open the tray menu.
-- **Middle-click** also toggles the popup on tray hosts that support secondary activation, such as KDE Plasma.
+- As a workaround, **middle-click** opens the KimaiTray popup/window.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -318,25 +318,6 @@ xattr -cr /Applications/KimaiTray.app
 chmod +x KimaiTray_*.AppImage
 ```
 
-**Linux: tray icon missing on KDE Plasma / Kubuntu**
-KimaiTray uses AppIndicator on KDE Plasma and Wayland sessions. Plasma supports
-these icons natively; GNOME may need an AppIndicator extension. Legacy GTK tray
-icons are used on Cinnamon, Xfce and MATE under X11.
-
-For KimaiTray releases without this fix that select the legacy backend on
-Plasma, quit KimaiTray and launch it with the backend override (substitute the
-AppImage path if needed):
-```sh
-KIMAITRAY_TRAY_BACKEND=appindicator kimaitray
-```
-If the icon appears but clicks do nothing, use a build containing this fix:
-affected KimaiTray releases can discard the required AppIndicator menu when
-the saved right-click action is set to "popup".
-
-On KDE Plasma, left/right clicks open the tray menu. Middle-click
-opens or hides KimaiTray directly on hosts such as Plasma that support secondary
-activation; **Show/Hide** in the menu is always available.
-
 **Windows: WebView2 missing**
 The NSIS installer bundles a WebView2 bootstrapper. If you built manually, install [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
 
@@ -349,6 +330,17 @@ D-Bus API on Wayland. Install `xprintidle` when using X11:
 ```sh
 sudo apt install xprintidle
 ```
+
+### Linux: Tray Icon
+
+- KimaiTray uses AppIndicator in **Wayland** sessions.
+- **GNOME Shell** _may_ need an AppIndicator extension to display the tray icon.
+- **Cinnamon**, **Xfce** and **MATE** use legacy GTK tray icons under **X11**.
+
+#### AppIndicator clicks
+
+- Tauri does not expose direct tray-click callbacks on Linux. Use **Show/Hide** in the tray menu to open or hide KimaiTray.
+- **Middle-click** also toggles the popup on tray hosts that support secondary activation, such as KDE Plasma.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,25 @@ xattr -cr /Applications/KimaiTray.app
 ```sh
 chmod +x KimaiTray_*.AppImage
 ```
-If using Wayland, the tray icon may require an AppIndicator extension.
+
+**Linux: tray icon missing on KDE Plasma / Kubuntu**
+KimaiTray uses AppIndicator on KDE Plasma and Wayland sessions. Plasma supports
+these icons natively; GNOME may need an AppIndicator extension. Legacy GTK tray
+icons are used on Cinnamon, Xfce and MATE under X11.
+
+For KimaiTray releases without this fix that select the legacy backend on
+Plasma, quit KimaiTray and launch it with the backend override (substitute the
+AppImage path if needed):
+```sh
+KIMAITRAY_TRAY_BACKEND=appindicator kimaitray
+```
+If the icon appears but clicks do nothing, use a build containing this fix:
+affected KimaiTray releases can discard the required AppIndicator menu when
+the saved right-click action is set to "popup".
+
+On KDE Plasma, left/right clicks open the tray menu. Middle-click
+opens or hides KimaiTray directly on hosts such as Plasma that support secondary
+activation; **Show/Hide** in the menu is always available.
 
 **Windows: WebView2 missing**
 The NSIS installer bundles a WebView2 bootstrapper. If you built manually, install [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).

--- a/README.md
+++ b/README.md
@@ -334,12 +334,12 @@ sudo apt install xprintidle
 ### Linux: Tray Icon
 
 - KimaiTray uses AppIndicator in **Wayland** sessions.
-- **GNOME Shell** _may_ need an AppIndicator extension to display the tray icon.
+- **GNOME** _may_ need an AppIndicator extension to display the tray icon.
 - **Cinnamon**, **Xfce** and **MATE** use legacy GTK tray icons under **X11**.
 
-#### AppIndicator clicks
+#### Wayland AppIndicator
 
-- Tauri does not expose direct tray-click callbacks on Linux. Use **Show/Hide** in the tray menu to open or hide KimaiTray.
+- Tauri does not expose direct left/right clicks on tray icons. Therefore, left/right click both open the tray menu.
 - **Middle-click** also toggles the popup on tray hosts that support secondary activation, such as KDE Plasma.
 
 ## License

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -720,7 +720,6 @@ fn linux_needs_appindicator(backend: Option<&str>, desktop: &str, is_wayland: bo
         return backend.eq_ignore_ascii_case("appindicator");
     }
     // GtkStatusIcon uses XEmbed and cannot create a native Wayland tray icon.
-    // Keep the existing desktop-specific backend selection on X11.
     is_wayland || desktop_name_needs_appindicator(&desktop.to_ascii_lowercase())
 }
 
@@ -1957,10 +1956,9 @@ fn attach_appindicator_popup_activation(app: &AppHandle) -> tauri::Result<()> {
         }
 
         let menu: gtk::Menu = unsafe { from_glib_none(menu_ptr) };
-        // Compatible tray hosts send middle-click requests through AppIndicator's
+        // On Linux with AppIndicator: send middle-click requests through AppIndicator's
         // secondary activation. Forward them to Show/Hide without relying on
-        // Tauri's unsupported Linux tray mouse events. The attached menu owns
-        // the target for as long as the indicator is alive.
+        // Tauri's unsupported Linux tray mouse events.
         if let Some(toggle_item) = menu.children().first() {
             unsafe {
                 libappindicator_sys::app_indicator_set_secondary_activate_target(

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -707,19 +707,25 @@ pub fn platform_tray_backend() -> &'static str {
 
 #[cfg(target_os = "linux")]
 fn desktop_needs_appindicator() -> bool {
-    if let Ok(backend) = std::env::var("KIMAITRAY_TRAY_BACKEND") {
-        return backend.eq_ignore_ascii_case("appindicator");
-    }
+    let backend = std::env::var("KIMAITRAY_TRAY_BACKEND").ok();
     let desktop = std::env::var("XDG_CURRENT_DESKTOP")
         .or_else(|_| std::env::var("XDG_SESSION_DESKTOP"))
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    desktop_name_needs_appindicator(&desktop)
+        .unwrap_or_default();
+    linux_needs_appindicator(backend.as_deref(), &desktop, crate::platform::is_wayland())
 }
 
 #[cfg(target_os = "linux")]
-fn desktop_name_needs_appindicator(desktop: &str) -> bool {
-    ["gnome", "ubuntu", "unity", "pantheon", "budgie", "sway"]
+fn linux_needs_appindicator(backend: Option<&str>, desktop: &str, is_wayland: bool) -> bool {
+    if let Some(backend) = backend {
+        return backend.eq_ignore_ascii_case("appindicator");
+    }
+    // GtkStatusIcon uses XEmbed and cannot create a native Wayland tray icon.
+    // Plasma uses StatusNotifierItem (provided by AppIndicator) on X11 too.
+    let desktop = desktop.to_ascii_lowercase();
+    is_wayland
+        || [
+            "gnome", "ubuntu", "unity", "pantheon", "budgie", "sway", "kde", "plasma",
+        ]
         .iter()
         .any(|name| desktop.contains(name))
 }
@@ -1155,17 +1161,56 @@ mod tests {
     use super::{parse_hex_color, tray_label_title, validate_popup_geometry, validate_text};
 
     #[cfg(target_os = "linux")]
-    use super::desktop_name_needs_appindicator;
+    use super::linux_needs_appindicator;
 
     #[cfg(target_os = "linux")]
     #[test]
     fn selects_tray_backend_for_common_linux_desktops() {
-        assert!(desktop_name_needs_appindicator("ubuntu:gnome"));
-        assert!(desktop_name_needs_appindicator("gnome"));
-        assert!(desktop_name_needs_appindicator("budgie:gnome"));
-        assert!(!desktop_name_needs_appindicator("x-cinnamon"));
-        assert!(!desktop_name_needs_appindicator("xfce"));
-        assert!(!desktop_name_needs_appindicator("mate"));
+        for desktop in [
+            "ubuntu:GNOME",
+            "GNOME",
+            "budgie:gnome",
+            "Unity",
+            "Pantheon",
+            "sway",
+        ] {
+            assert!(linux_needs_appindicator(None, desktop, false), "{desktop}");
+        }
+        for desktop in ["X-Cinnamon", "XFCE", "MATE"] {
+            assert!(!linux_needs_appindicator(None, desktop, false), "{desktop}");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn plasma_uses_appindicator_on_x11_and_wayland() {
+        for desktop in ["KDE", "kde", "Plasma", "plasmawayland", "KDE:Plasma"] {
+            for is_wayland in [false, true] {
+                assert!(
+                    linux_needs_appindicator(None, desktop, is_wayland),
+                    "{desktop}"
+                );
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn wayland_never_defaults_to_xembed() {
+        for desktop in ["", "unknown", "X-Cinnamon", "XFCE", "MATE"] {
+            assert!(linux_needs_appindicator(None, desktop, true), "{desktop}");
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn explicit_tray_backend_overrides_desktop_and_session_detection() {
+        assert!(linux_needs_appindicator(
+            Some("AppIndicator"),
+            "XFCE",
+            false
+        ));
+        assert!(!linux_needs_appindicator(Some("legacy-gtk"), "KDE", true));
     }
 
     #[test]
@@ -1870,7 +1915,11 @@ fn create_tauri_tray(app: &AppHandle) -> tauri::Result<()> {
     #[cfg(target_os = "linux")]
     attach_appindicator_popup_activation(app)?;
 
-    // If right-click is configured to show popup, remove the attached menu
+    // AppIndicator needs its menu even when a saved click action requests the
+    // popup: the menu is also the Linux activation bridge.
+    #[cfg(target_os = "linux")]
+    let _ = right_action_popup;
+    #[cfg(not(target_os = "linux"))]
     if right_action_popup {
         if let Some(tray) = app.tray_by_id("main") {
             let _ = tray.set_menu(None::<Menu<tauri::Wry>>);
@@ -1907,6 +1956,18 @@ fn attach_appindicator_popup_activation(app: &AppHandle) -> tauri::Result<()> {
         }
 
         let menu: gtk::Menu = unsafe { from_glib_none(menu_ptr) };
+        // Plasma sends SecondaryActivate for a middle click. AppIndicator
+        // forwards it to this visible menu item, so reuse Show/Hide without
+        // relying on Tauri's unsupported Linux tray mouse events. The attached
+        // menu owns the target for as long as the indicator is alive.
+        if let Some(toggle_item) = menu.children().first() {
+            unsafe {
+                libappindicator_sys::app_indicator_set_secondary_activate_target(
+                    raw,
+                    toggle_item.to_glib_none().0,
+                );
+            }
+        }
         menu.connect_show(move |menu| {
             // GNOME/Ubuntu owns AppIndicator clicks and only tells the app to
             // show its menu. Treat that signal as activation, close the menu,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -720,12 +720,13 @@ fn linux_needs_appindicator(backend: Option<&str>, desktop: &str, is_wayland: bo
         return backend.eq_ignore_ascii_case("appindicator");
     }
     // GtkStatusIcon uses XEmbed and cannot create a native Wayland tray icon.
-    // Plasma uses StatusNotifierItem (provided by AppIndicator) on X11 too.
-    let desktop = desktop.to_ascii_lowercase();
-    is_wayland
-        || [
-            "gnome", "ubuntu", "unity", "pantheon", "budgie", "sway", "kde", "plasma",
-        ]
+    // Keep the existing desktop-specific backend selection on X11.
+    is_wayland || desktop_name_needs_appindicator(&desktop.to_ascii_lowercase())
+}
+
+#[cfg(target_os = "linux")]
+fn desktop_name_needs_appindicator(desktop: &str) -> bool {
+    ["gnome", "ubuntu", "unity", "pantheon", "budgie", "sway"]
         .iter()
         .any(|name| desktop.contains(name))
 }
@@ -1168,6 +1169,7 @@ mod tests {
     fn selects_tray_backend_for_common_linux_desktops() {
         for desktop in [
             "ubuntu:GNOME",
+            "gnome",
             "GNOME",
             "budgie:gnome",
             "Unity",
@@ -1183,22 +1185,21 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn plasma_uses_appindicator_on_x11_and_wayland() {
-        for desktop in ["KDE", "kde", "Plasma", "plasmawayland", "KDE:Plasma"] {
-            for is_wayland in [false, true] {
-                assert!(
-                    linux_needs_appindicator(None, desktop, is_wayland),
-                    "{desktop}"
-                );
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn wayland_never_defaults_to_xembed() {
-        for desktop in ["", "unknown", "X-Cinnamon", "XFCE", "MATE"] {
+    fn wayland_uses_appindicator_without_changing_legacy_x11_desktops() {
+        for desktop in [
+            "KDE",
+            "kde",
+            "Plasma",
+            "plasmawayland",
+            "KDE:Plasma",
+            "X-Cinnamon",
+            "XFCE",
+            "MATE",
+            "unknown",
+            "",
+        ] {
             assert!(linux_needs_appindicator(None, desktop, true), "{desktop}");
+            assert!(!linux_needs_appindicator(None, desktop, false), "{desktop}");
         }
     }
 
@@ -1956,10 +1957,10 @@ fn attach_appindicator_popup_activation(app: &AppHandle) -> tauri::Result<()> {
         }
 
         let menu: gtk::Menu = unsafe { from_glib_none(menu_ptr) };
-        // Plasma sends SecondaryActivate for a middle click. AppIndicator
-        // forwards it to this visible menu item, so reuse Show/Hide without
-        // relying on Tauri's unsupported Linux tray mouse events. The attached
-        // menu owns the target for as long as the indicator is alive.
+        // Compatible tray hosts send middle-click requests through AppIndicator's
+        // secondary activation. Forward them to Show/Hide without relying on
+        // Tauri's unsupported Linux tray mouse events. The attached menu owns
+        // the target for as long as the indicator is alive.
         if let Some(toggle_item) = menu.children().first() {
             unsafe {
                 libappindicator_sys::app_indicator_set_secondary_activate_target(


### PR DESCRIPTION
## Summary:
This PR fixes missing tray icons on Wayland sessions such as KDE Plasma, where KimaiTray previously selected the legacy GTK backend.
Also adds middle-click activation since Tauri’s Linux/AppIndicator backend does not expose direct left/right clicks on tray icons.

- Select AppIndicator for Wayland sessions while preserving X11 desktop selection and explicit backend overrides.
- Keep the required AppIndicator menu attached regardless of the configured right-click action.
- Connect middle-click secondary activation to Show/Hide on tray host supporting secondary activation.
- Expand backend-selection regression tests and update Linux tray documentation.

## Validation:
```bash
cargo fmt --check
cargo check --locked
cargo test --locked
```
--> all 40 tests pass successfully.
- Tray visibility, menu actions, and middle-click activation were manually verified on KDE Plasma in a Wayland session.
- Ubuntu GNOME was _not_ yet tested by myself.

## LLM disclosure:
Developed with assistance from GPT- 6 Astra (Extra High). The LLM helped me identify the related files, code parts and proposed possible fixes.
I've manually reviewed the code the best I could, but since my coding capabilities are not that good yet, proper code review is required in any case.