### PR TITLE
fix: Tray popup resizing / persist both dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Built with [Tauri 2](https://tauri.app/), React 19 and TypeScript.
 - Four popup layouts: Classic, Focus, Taskbar and Timeline
 - Light, dark and transparent themes, five accent colors and configurable Kimai color indicators
 - UI scaling from 85% to 160%, optional rounded corners, animations and translucency controls
-- Resizable tray-popup and detached-window modes; tray-popup width and height are remembered
+- Resizable tray-popup and detached-window modes
 - macOS True Tray mode hides the Dock and Cmd+Tab entry
 - Custom tray icon shape, size and colors for running, paused, idle and error states
 - Configurable macOS menu-bar label (timer, project, activity or icon only) and tray left/right-click actions

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Built with [Tauri 2](https://tauri.app/), React 19 and TypeScript.
 - Four popup layouts: Classic, Focus, Taskbar and Timeline
 - Light, dark and transparent themes, five accent colors and configurable Kimai color indicators
 - UI scaling from 85% to 160%, optional rounded corners, animations and translucency controls
-- Tray or resizable detached-window mode; macOS True Tray mode hides the Dock and Cmd+Tab entry
+- Resizable tray-popup and detached-window modes; tray-popup width and height are remembered
+- macOS True Tray mode hides the Dock and Cmd+Tab entry
 - Custom tray icon shape, size and colors for running, paused, idle and error states
 - Configurable macOS menu-bar label (timer, project, activity or icon only) and tray left/right-click actions
 - Configurable popup monitor and placement on supported Linux/X11 desktops

--- a/contracts/ipc-contract.json
+++ b/contracts/ipc-contract.json
@@ -24,6 +24,7 @@
     "noTimerReminderMinutes",
     "theme",
     "uiSize",
+    "popupWidth",
     "popupHeight",
     "roundedPopupCorners",
     "reduceVisualEffects",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSSt
 window-vibrancy = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_System_SystemInformation"] }
+windows-sys = { version = "0.61", features = ["Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging", "Win32_System_SystemInformation"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # GtkStatusIcon is deprecated upstream, but remains the most compatible tray

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "core:window:allow-show",
     "core:window:allow-hide",
     "core:window:allow-set-focus",
+    "core:window:allow-scale-factor",
     "core:window:allow-set-simple-fullscreen",
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,7 +309,6 @@ pub fn run() {
                 tauri::WindowEvent::Focused(focused) => {
                     tray::on_popup_focus_changed(window, *focused);
                 }
-                #[cfg(target_os = "linux")]
                 tauri::WindowEvent::Resized(_) => tray::on_popup_resize(),
                 _ => {}
             },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -305,11 +305,14 @@ pub fn run() {
             Ok(())
         })
         .on_window_event(|window, event| match window.label() {
-            "tray-popup" => {
-                if let tauri::WindowEvent::Focused(false) = event {
-                    tray::on_popup_blur(window);
+            "tray-popup" => match event {
+                tauri::WindowEvent::Focused(focused) => {
+                    tray::on_popup_focus_changed(window, *focused);
                 }
-            }
+                #[cfg(target_os = "linux")]
+                tauri::WindowEvent::Resized(_) => tray::on_popup_resize(),
+                _ => {}
+            },
             "settings" | "changelog" => {
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                     api.prevent_close();

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -313,13 +313,18 @@ fn validate_settings_patch_window(
         return Err("Window is not authorized to patch these settings".into());
     }
 
-    if values.len() == 1 && values.contains_key("popupHeight") {
-        let height = values
-            .get("popupHeight")
-            .and_then(Value::as_i64)
-            .ok_or("Popup height must be an integer")?;
-        if !(320..=1200).contains(&height) {
-            return Err("Popup height must be between 320 and 1200".into());
+    if !values.is_empty()
+        && values
+            .keys()
+            .all(|key| matches!(key.as_str(), "popupWidth" | "popupHeight"))
+    {
+        for (key, minimum, maximum) in [("popupWidth", 300, 1000), ("popupHeight", 320, 1200)] {
+            if let Some(value) = values.get(key) {
+                let dimension = value.as_i64().ok_or("Popup dimensions must be integers")?;
+                if !(minimum..=maximum).contains(&dimension) {
+                    return Err(format!("{key} must be between {minimum} and {maximum}"));
+                }
+            }
         }
         return Ok(());
     }
@@ -1060,6 +1065,38 @@ mod tests {
         )
         .is_err());
         assert!(validate_settings_patch_window("settings", &settings, &arbitrary_url).is_ok());
+    }
+
+    #[test]
+    fn tray_can_persist_bounded_dimensions_without_changing_other_settings() {
+        let settings = Map::new();
+        for dimensions in [
+            json!({"popupWidth": 300}),
+            json!({"popupWidth": 1000, "popupHeight": 1200}),
+            json!({"popupWidth": 600, "popupHeight": 700}),
+        ] {
+            assert!(validate_settings_patch_window(
+                "tray-popup",
+                &settings,
+                dimensions.as_object().unwrap(),
+            )
+            .is_ok());
+        }
+        for invalid in [
+            json!({"popupWidth": 299}),
+            json!({"popupWidth": 1001}),
+            json!({"popupWidth": 600.5}),
+            json!({"popupWidth": "600"}),
+            json!({"popupWidth": 600, "popupHeight": 1201}),
+            json!({"popupWidth": 600, "theme": "dark"}),
+        ] {
+            assert!(validate_settings_patch_window(
+                "tray-popup",
+                &settings,
+                invalid.as_object().unwrap(),
+            )
+            .is_err());
+        }
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -624,6 +624,10 @@ fn draw_clock(color: Rgb, radius: f64) -> Vec<u8> {
 }
 
 static LAST_POPUP_HIDE: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "linux")]
+static POPUP_FOCUS_GENERATION: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "linux")]
+static LAST_POPUP_RESIZE: AtomicU64 = AtomicU64::new(0);
 // 0 = popup, 1 = nothing
 static TRAY_LEFT_ACTION: AtomicU8 = AtomicU8::new(0);
 // 0 = menu, 1 = popup
@@ -784,12 +788,89 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-pub fn on_popup_blur(window: &tauri::Window) {
+#[cfg(target_os = "linux")]
+#[derive(Debug, PartialEq)]
+enum PopupBlurAction {
+    KeepOpen,
+    Wait,
+    Hide,
+}
+
+#[cfg(target_os = "linux")]
+fn popup_blur_action(focused: bool, pointer_down: bool, since_resize_ms: u64) -> PopupBlurAction {
+    if focused {
+        PopupBlurAction::KeepOpen
+    } else if pointer_down || since_resize_ms < 250 {
+        PopupBlurAction::Wait
+    } else {
+        PopupBlurAction::Hide
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn on_popup_resize() {
+    LAST_POPUP_RESIZE.store(now_ms(), Ordering::SeqCst);
+}
+
+pub fn on_popup_focus_changed(window: &tauri::Window, focused: bool) {
+    #[cfg(target_os = "linux")]
+    let generation = POPUP_FOCUS_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
+    if focused {
+        return;
+    }
     if DISPLAY_MODE.load(Ordering::SeqCst) == 1 {
         return;
     }
-    LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
-    let _ = window.hide();
+    #[cfg(target_os = "linux")]
+    {
+        // GTK reports temporary focus loss during compositor resize operations
+        // and pointer grabs. Wait for the interaction to finish, then check the
+        // native focus state instead of dismissing the popup mid-drag.
+        let Ok(native) = window.gtk_window() else {
+            return;
+        };
+        let window = window.clone();
+        glib::timeout_add_local(Duration::from_millis(100), move || {
+            if POPUP_FOCUS_GENERATION.load(Ordering::SeqCst) != generation
+                || is_detached()
+                || !native.is_visible()
+            {
+                return glib::ControlFlow::Break;
+            }
+            let pointer_down = native.window().is_some_and(|surface| {
+                surface
+                    .display()
+                    .default_seat()
+                    .and_then(|seat| seat.pointer())
+                    .is_some_and(|pointer| {
+                        let (_, _, _, modifiers) = surface.device_position(&pointer);
+                        modifiers.intersects(
+                            gdk::ModifierType::BUTTON1_MASK
+                                | gdk::ModifierType::BUTTON2_MASK
+                                | gdk::ModifierType::BUTTON3_MASK,
+                        )
+                    })
+            });
+            match popup_blur_action(
+                native.is_active() || native.has_toplevel_focus(),
+                pointer_down,
+                now_ms().saturating_sub(LAST_POPUP_RESIZE.load(Ordering::SeqCst)),
+            ) {
+                PopupBlurAction::KeepOpen => glib::ControlFlow::Break,
+                PopupBlurAction::Wait => glib::ControlFlow::Continue,
+                PopupBlurAction::Hide => {
+                    LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
+                    let _ = window.hide();
+                    glib::ControlFlow::Break
+                }
+            }
+        });
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
+        let _ = window.hide();
+    }
 }
 
 pub fn is_detached() -> bool {
@@ -1156,6 +1237,22 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     use super::desktop_name_needs_appindicator;
+
+    #[cfg(target_os = "linux")]
+    use super::{popup_blur_action, PopupBlurAction};
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn popup_survives_transient_focus_loss_during_pointer_and_resize_grabs() {
+        assert_eq!(
+            popup_blur_action(true, false, 1_000),
+            PopupBlurAction::KeepOpen
+        );
+        assert_eq!(popup_blur_action(false, true, 1_000), PopupBlurAction::Wait);
+        assert_eq!(popup_blur_action(false, false, 0), PopupBlurAction::Wait);
+        assert_eq!(popup_blur_action(false, false, 249), PopupBlurAction::Wait);
+        assert_eq!(popup_blur_action(false, false, 250), PopupBlurAction::Hide);
+    }
 
     #[cfg(target_os = "linux")]
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -895,7 +895,7 @@ pub fn set_display_mode(app: AppHandle, mode: String) -> Result<(), String> {
 
     if detached {
         // Detached windows should be freely resizable. Tray mode restores
-        // the fixed-width / bounded-height constraints in set_popup_size.
+        // the bounded width and height constraints in set_popup_size.
         window
             .set_min_size(None::<tauri::Size>)
             .map_err(|e| e.to_string())?;
@@ -1179,11 +1179,11 @@ fn position_legacy_popup(window: &WebviewWindow) -> tauri::Result<()> {
 static VIBRANCY_APPLIED: AtomicBool = AtomicBool::new(false);
 
 fn validate_popup_geometry(width: f64, height: f64, zoom: f64) -> Result<(), String> {
-    if !width.is_finite() || !(240.0..=1600.0).contains(&width) {
-        return Err("Popup width must be between 240 and 1600".into());
-    }
     if !zoom.is_finite() || !(0.5..=2.5).contains(&zoom) {
         return Err("Popup zoom must be between 0.5 and 2.5".into());
+    }
+    if !width.is_finite() || !(300.0 * zoom..=1000.0 * zoom).contains(&width) {
+        return Err("Popup width must be between 300 and 1000".into());
     }
     if !height.is_finite() || !(320.0 * zoom..=1200.0 * zoom).contains(&height) {
         return Err("Popup height must be between 320 and 1200".into());
@@ -1293,6 +1293,8 @@ mod tests {
     fn popup_geometry_accepts_supported_values() {
         assert!(validate_popup_geometry(360.0, 640.0, 1.0).is_ok());
         assert!(validate_popup_geometry(576.0, 1920.0, 1.6).is_ok());
+        assert!(validate_popup_geometry(255.0, 544.0, 0.85).is_ok());
+        assert!(validate_popup_geometry(1600.0, 1920.0, 1.6).is_ok());
     }
 
     #[test]
@@ -1300,6 +1302,8 @@ mod tests {
         assert!(validate_popup_geometry(f64::NAN, 640.0, 1.0).is_err());
         assert!(validate_popup_geometry(360.0, f64::INFINITY, 1.0).is_err());
         assert!(validate_popup_geometry(360.0, 640.0, 10.0).is_err());
+        assert!(validate_popup_geometry(299.0, 640.0, 1.0).is_err());
+        assert!(validate_popup_geometry(1601.0, 1920.0, 1.6).is_err());
     }
 
     #[test]
@@ -1319,14 +1323,14 @@ pub fn set_popup_size(app: AppHandle, width: f64, height: f64, zoom: f64) -> Res
         .ok_or("Popup not found")?;
     let size = tauri::Size::Logical(tauri::LogicalSize { width, height });
 
-    // Keep the popup width fixed while allowing the user to resize its
-    // height. Values are logical pixels, so scale the bounds with the UI zoom.
+    // Allow both edges to resize. Equal width bounds suppress GTK's horizontal
+    // resize handle. Values are logical pixels scaled with the UI zoom.
     let min_size = tauri::Size::Logical(tauri::LogicalSize {
-        width,
+        width: 300.0 * zoom,
         height: 320.0 * zoom,
     });
     let max_size = tauri::Size::Logical(tauri::LogicalSize {
-        width,
+        width: 1000.0 * zoom,
         height: 1200.0 * zoom,
     });
     window.set_resizable(true).map_err(|e| e.to_string())?;

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1453,8 +1453,7 @@ pub fn set_popup_size(app: AppHandle, width: f64, height: f64, zoom: f64) -> Res
         .ok_or("Popup not found")?;
     let size = tauri::Size::Logical(tauri::LogicalSize { width, height });
 
-    // Allow both edges to resize. Equal width bounds suppress GTK's horizontal
-    // resize handle. Values are logical pixels scaled with the UI zoom.
+    // Allow width and height resizing within bounds scaled by the UI zoom.
     let min_size = tauri::Size::Logical(tauri::LogicalSize {
         width: 300.0 * zoom,
         height: 320.0 * zoom,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -624,9 +624,7 @@ fn draw_clock(color: Rgb, radius: f64) -> Vec<u8> {
 }
 
 static LAST_POPUP_HIDE: AtomicU64 = AtomicU64::new(0);
-#[cfg(target_os = "linux")]
 static POPUP_FOCUS_GENERATION: AtomicU64 = AtomicU64::new(0);
-#[cfg(target_os = "linux")]
 static LAST_POPUP_RESIZE: AtomicU64 = AtomicU64::new(0);
 // 0 = popup, 1 = nothing
 static TRAY_LEFT_ACTION: AtomicU8 = AtomicU8::new(0);
@@ -788,7 +786,6 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-#[cfg(target_os = "linux")]
 #[derive(Debug, PartialEq)]
 enum PopupBlurAction {
     KeepOpen,
@@ -796,81 +793,176 @@ enum PopupBlurAction {
     Hide,
 }
 
-#[cfg(target_os = "linux")]
-fn popup_blur_action(focused: bool, pointer_down: bool, since_resize_ms: u64) -> PopupBlurAction {
+fn popup_blur_action(
+    focused: bool,
+    pointer_down: bool,
+    resizing: bool,
+    since_resize_ms: u64,
+) -> PopupBlurAction {
     if focused {
         PopupBlurAction::KeepOpen
-    } else if pointer_down || since_resize_ms < 250 {
+    } else if pointer_down || resizing || since_resize_ms < 250 {
         PopupBlurAction::Wait
     } else {
         PopupBlurAction::Hide
     }
 }
 
+struct PopupInteraction {
+    focused: bool,
+    pointer_down: bool,
+    resizing: bool,
+}
+
+// Called only by the dismissal check dispatched to the UI thread.
 #[cfg(target_os = "linux")]
+fn popup_interaction(window: &tauri::Window) -> Option<PopupInteraction> {
+    let native = window.gtk_window().ok()?;
+    let pointer_down = native.window().is_some_and(|surface| {
+        surface
+            .display()
+            .default_seat()
+            .and_then(|seat| seat.pointer())
+            .is_some_and(|pointer| {
+                let (_, _, _, modifiers) = surface.device_position(&pointer);
+                modifiers.intersects(
+                    gdk::ModifierType::BUTTON1_MASK
+                        | gdk::ModifierType::BUTTON2_MASK
+                        | gdk::ModifierType::BUTTON3_MASK,
+                )
+            })
+    });
+    Some(PopupInteraction {
+        focused: native.is_active() || native.has_toplevel_focus(),
+        pointer_down,
+        resizing: false,
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn popup_interaction(window: &tauri::Window) -> Option<PopupInteraction> {
+    use windows_sys::Win32::UI::{
+        Input::KeyboardAndMouse::{GetAsyncKeyState, VK_LBUTTON, VK_MBUTTON, VK_RBUTTON},
+        WindowsAndMessaging::{
+            GetForegroundWindow, GetGUIThreadInfo, GetWindowThreadProcessId, GUITHREADINFO,
+            GUI_INMOVESIZE,
+        },
+    };
+
+    let hwnd = window.hwnd().ok()?.0;
+    // Query the popup's own GUI thread so another application's move/resize
+    // operation cannot keep this popup open. No window handles are retained.
+    unsafe {
+        let thread_id = GetWindowThreadProcessId(hwnd, std::ptr::null_mut());
+        if thread_id == 0 {
+            return None;
+        }
+        let mut info = GUITHREADINFO {
+            cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
+            ..Default::default()
+        };
+        let resizing = GetGUIThreadInfo(thread_id, &mut info) != 0
+            && info.flags & GUI_INMOVESIZE != 0
+            && info.hwndMoveSize == hwnd;
+        Some(PopupInteraction {
+            focused: GetForegroundWindow() == hwnd,
+            pointer_down: [VK_LBUTTON, VK_MBUTTON, VK_RBUTTON]
+                .into_iter()
+                .any(|button| GetAsyncKeyState(button as i32) < 0),
+            resizing,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn popup_interaction(window: &tauri::Window) -> Option<PopupInteraction> {
+    use objc::runtime::{Object, BOOL, NO};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    let native = window.ns_window().ok()?.cast::<Object>();
+    if native.is_null() {
+        return None;
+    }
+    // Tauri owns the NSWindow; all AppKit queries run on its UI thread.
+    unsafe {
+        let focused: BOOL = msg_send![native, isKeyWindow];
+        let resizing: BOOL = msg_send![native, inLiveResize];
+        let buttons: usize = msg_send![class!(NSEvent), pressedMouseButtons];
+        Some(PopupInteraction {
+            focused: focused != NO,
+            pointer_down: buttons & 0b111 != 0,
+            resizing: resizing != NO,
+        })
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+fn popup_interaction(window: &tauri::Window) -> Option<PopupInteraction> {
+    Some(PopupInteraction {
+        focused: window.is_focused().ok()?,
+        pointer_down: false,
+        resizing: false,
+    })
+}
+
 pub fn on_popup_resize() {
     LAST_POPUP_RESIZE.store(now_ms(), Ordering::SeqCst);
 }
 
+fn recheck_popup_blur(window: &tauri::Window, generation: u64) -> bool {
+    if POPUP_FOCUS_GENERATION.load(Ordering::SeqCst) != generation
+        || is_detached()
+        || !window.is_visible().unwrap_or(false)
+    {
+        return false;
+    }
+    let Some(interaction) = popup_interaction(window) else {
+        return false;
+    };
+    match popup_blur_action(
+        interaction.focused,
+        interaction.pointer_down,
+        interaction.resizing,
+        now_ms().saturating_sub(LAST_POPUP_RESIZE.load(Ordering::SeqCst)),
+    ) {
+        // Child-window focus events can disagree with native foreground focus.
+        // Keep watching for a real click away unless a focus-in event cancels us.
+        PopupBlurAction::KeepOpen | PopupBlurAction::Wait => true,
+        PopupBlurAction::Hide => {
+            LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
+            let _ = window.hide();
+            false
+        }
+    }
+}
+
 pub fn on_popup_focus_changed(window: &tauri::Window, focused: bool) {
-    #[cfg(target_os = "linux")]
     let generation = POPUP_FOCUS_GENERATION.fetch_add(1, Ordering::SeqCst) + 1;
-    if focused {
+    if focused || is_detached() {
         return;
     }
-    if DISPLAY_MODE.load(Ordering::SeqCst) == 1 {
-        return;
-    }
-    #[cfg(target_os = "linux")]
-    {
-        // GTK reports temporary focus loss during compositor resize operations
-        // and pointer grabs. Wait for the interaction to finish, then check the
-        // native focus state instead of dismissing the popup mid-drag.
-        let Ok(native) = window.gtk_window() else {
-            return;
-        };
-        let window = window.clone();
-        glib::timeout_add_local(Duration::from_millis(100), move || {
-            if POPUP_FOCUS_GENERATION.load(Ordering::SeqCst) != generation
-                || is_detached()
-                || !native.is_visible()
+    let window = window.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if POPUP_FOCUS_GENERATION.load(Ordering::SeqCst) != generation {
+                break;
+            }
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            let handle = window.clone();
+            if window
+                .run_on_main_thread(move || {
+                    let _ = sender.send(recheck_popup_blur(&handle, generation));
+                })
+                .is_err()
             {
-                return glib::ControlFlow::Break;
+                break;
             }
-            let pointer_down = native.window().is_some_and(|surface| {
-                surface
-                    .display()
-                    .default_seat()
-                    .and_then(|seat| seat.pointer())
-                    .is_some_and(|pointer| {
-                        let (_, _, _, modifiers) = surface.device_position(&pointer);
-                        modifiers.intersects(
-                            gdk::ModifierType::BUTTON1_MASK
-                                | gdk::ModifierType::BUTTON2_MASK
-                                | gdk::ModifierType::BUTTON3_MASK,
-                        )
-                    })
-            });
-            match popup_blur_action(
-                native.is_active() || native.has_toplevel_focus(),
-                pointer_down,
-                now_ms().saturating_sub(LAST_POPUP_RESIZE.load(Ordering::SeqCst)),
-            ) {
-                PopupBlurAction::KeepOpen => glib::ControlFlow::Break,
-                PopupBlurAction::Wait => glib::ControlFlow::Continue,
-                PopupBlurAction::Hide => {
-                    LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
-                    let _ = window.hide();
-                    glib::ControlFlow::Break
-                }
+            if !receiver.await.unwrap_or(false) {
+                break;
             }
-        });
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        LAST_POPUP_HIDE.store(now_ms(), Ordering::SeqCst);
-        let _ = window.hide();
-    }
+        }
+    });
 }
 
 pub fn is_detached() -> bool {
@@ -1238,20 +1330,58 @@ mod tests {
     #[cfg(target_os = "linux")]
     use super::desktop_name_needs_appindicator;
 
-    #[cfg(target_os = "linux")]
     use super::{popup_blur_action, PopupBlurAction};
 
-    #[cfg(target_os = "linux")]
     #[test]
     fn popup_survives_transient_focus_loss_during_pointer_and_resize_grabs() {
         assert_eq!(
-            popup_blur_action(true, false, 1_000),
+            popup_blur_action(true, false, false, 1_000),
             PopupBlurAction::KeepOpen
         );
-        assert_eq!(popup_blur_action(false, true, 1_000), PopupBlurAction::Wait);
-        assert_eq!(popup_blur_action(false, false, 0), PopupBlurAction::Wait);
-        assert_eq!(popup_blur_action(false, false, 249), PopupBlurAction::Wait);
-        assert_eq!(popup_blur_action(false, false, 250), PopupBlurAction::Hide);
+        assert_eq!(
+            popup_blur_action(false, true, false, 1_000),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(false, false, false, 0),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(false, false, false, 249),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(false, false, false, 250),
+            PopupBlurAction::Hide
+        );
+    }
+
+    #[test]
+    fn keyboard_resize_waits_even_without_mouse_buttons_or_recent_resize_events() {
+        assert_eq!(
+            popup_blur_action(false, false, true, 30_000),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(false, false, false, 10),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(true, false, false, 300),
+            PopupBlurAction::KeepOpen
+        );
+    }
+
+    #[test]
+    fn real_focus_loss_dismisses_after_the_pointer_is_released() {
+        assert_eq!(
+            popup_blur_action(false, true, false, 30_000),
+            PopupBlurAction::Wait
+        );
+        assert_eq!(
+            popup_blur_action(false, false, false, 30_000),
+            PopupBlurAction::Hide
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/hooks/useAppearance.test.tsx
+++ b/src/hooks/useAppearance.test.tsx
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   scaleFactor: vi.fn(),
   onResized: vi.fn(),
   resizeCleanup: vi.fn(),
-  resizeListener: undefined as ((event: { payload: { height: number } }) => void) | undefined,
+  resizeListener: undefined as ((event: { payload: { width: number; height: number } }) => void) | undefined,
   loadSettings: vi.fn(),
   onSettingsChange: vi.fn(),
   patchSettings: vi.fn(),
@@ -56,6 +56,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     theme: "light",
     popupLayout: "classic",
     displayMode: "tray",
+    popupWidth: 360,
     popupHeight: 640,
     trayIconSize: "medium",
     trayIconShape: "dot",
@@ -122,15 +123,15 @@ describe("appearance synchronization", () => {
     });
     expect(document.documentElement.classList.contains("dark")).toBe(false);
 
-    act(() => mocks.resizeListener?.({ payload: { height: 100 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 100 } }));
     await waitFor(
-      () => expect(mocks.patchSettings).toHaveBeenCalledWith({ popupHeight: 320 }),
+      () => expect(mocks.patchSettings).toHaveBeenCalledWith({ popupWidth: 360, popupHeight: 320 }),
       { timeout: 1_000 },
     );
 
-    act(() => mocks.resizeListener?.({ payload: { height: 9_999 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 9_999 } }));
     await waitFor(
-      () => expect(mocks.patchSettings).toHaveBeenCalledWith({ popupHeight: 1_200 }),
+      () => expect(mocks.patchSettings).toHaveBeenCalledWith({ popupWidth: 360, popupHeight: 1_200 }),
       { timeout: 1_000 },
     );
 
@@ -174,6 +175,7 @@ describe("appearance synchronization", () => {
     document.documentElement.dataset.window = "settings";
     mocks.loadSettings.mockResolvedValue(settings({
       theme: "dark",
+      popupWidth: 0,
       popupHeight: 0,
       displayMode: undefined,
       trayIconSize: undefined,
@@ -193,22 +195,55 @@ describe("appearance synchronization", () => {
     vi.useFakeTimers();
     const { unmount } = renderHook(() => useAppearance());
     await act(async () => Promise.resolve());
-    act(() => mocks.resizeListener?.({ payload: { height: 1_280 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 1_280 } }));
     expect(mocks.patchSettings).not.toHaveBeenCalled();
 
     act(() => mocks.settingsListener?.(settings({ popupHeight: 600 })));
-    act(() => mocks.resizeListener?.({ payload: { height: 1_200 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 1_200 } }));
     expect(mocks.patchSettings).not.toHaveBeenCalled();
     mocks.patchSettings.mockRejectedValueOnce(new Error("disk"));
-    act(() => mocks.resizeListener?.({ payload: { height: 1_400 } }));
-    act(() => mocks.resizeListener?.({ payload: { height: 1_600 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 1_400 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 1_600 } }));
     await act(async () => vi.advanceTimersByTime(250));
     expect(mocks.patchSettings).toHaveBeenCalledTimes(1);
-    expect(mocks.patchSettings).toHaveBeenCalledWith({ popupHeight: 800 });
+    expect(mocks.patchSettings).toHaveBeenCalledWith({ popupWidth: 360, popupHeight: 800 });
 
     act(() => mocks.settingsListener?.(settings({ displayMode: "detached" })));
-    act(() => mocks.resizeListener?.({ payload: { height: 2_000 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 720, height: 2_000 } }));
     expect(mocks.patchSettings).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("restores width and persists horizontal resizing with display and UI scaling", async () => {
+    vi.useFakeTimers();
+    mocks.loadSettings.mockResolvedValue(settings({ popupWidth: 500, uiSize: "scale130" }));
+    const { unmount } = renderHook(() => useAppearance());
+    await act(async () => Promise.resolve());
+    expect(mocks.setPopupSize).toHaveBeenLastCalledWith(650, 832, 1.3);
+
+    act(() => mocks.resizeListener?.({ payload: { width: 1560, height: 1664 } }));
+    await act(async () => vi.advanceTimersByTime(250));
+    expect(mocks.patchSettings).toHaveBeenLastCalledWith({ popupWidth: 600, popupHeight: 640 });
+
+    // A subsequent height change must not reset the user-selected width.
+    act(() => mocks.settingsListener?.(settings({ popupWidth: 600, popupHeight: 700, uiSize: "scale130" })));
+    expect(mocks.setPopupSize).toHaveBeenLastCalledWith(780, 910, 1.3);
+    unmount();
+  });
+
+  it("bounds horizontal resizing and saves the last complete size", async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useAppearance());
+    await act(async () => Promise.resolve());
+    act(() => mocks.resizeListener?.({ payload: { width: 100, height: 1280 } }));
+    await act(async () => vi.advanceTimersByTime(250));
+    expect(mocks.patchSettings).toHaveBeenLastCalledWith({ popupWidth: 300, popupHeight: 640 });
+
+    act(() => mocks.resizeListener?.({ payload: { width: 9999, height: 1280 } }));
+    act(() => mocks.resizeListener?.({ payload: { width: 9999, height: 1600 } }));
+    await act(async () => vi.advanceTimersByTime(250));
+    expect(mocks.patchSettings).toHaveBeenLastCalledWith({ popupWidth: 1000, popupHeight: 800 });
+    expect(mocks.patchSettings).toHaveBeenCalledTimes(2);
     unmount();
   });
 

--- a/src/hooks/useAppearance.ts
+++ b/src/hooks/useAppearance.ts
@@ -6,6 +6,8 @@ import type { AppSettings } from "../types";
 
 const POPUP_BASE_WIDTH = 360;
 const POPUP_BASE_HEIGHT = 640;
+const POPUP_MIN_WIDTH = 300;
+const POPUP_MAX_WIDTH = 1000;
 const POPUP_MIN_HEIGHT = 320;
 const POPUP_MAX_HEIGHT = 1200;
 
@@ -68,7 +70,7 @@ function apply(s: AppSettings) {
   const scale = UI_SIZE_SCALE[s.uiSize];
 
   if (!isDetached) {
-    const w = Math.round(POPUP_BASE_WIDTH * scale);
+    const w = Math.round((s.popupWidth || POPUP_BASE_WIDTH) * scale);
     const baseHeight = s.popupHeight || POPUP_BASE_HEIGHT;
     const h = Math.round(baseHeight * scale);
     const sizeKey = `tray:${w}:${h}:${scale}`;
@@ -119,7 +121,7 @@ export function useAppearance() {
     let active = true;
     let currentSettings: AppSettings | null = null;
     let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-    let pendingHeight: number | null = null;
+    let pendingSize: Pick<AppSettings, "popupWidth" | "popupHeight"> | null = null;
     let removeResizeListener: (() => void) | null = null;
     const currentWindow = getCurrentWindow();
     const resizeListener =
@@ -130,6 +132,10 @@ export function useAppearance() {
               if (!settings || settings.displayMode === "detached") return;
 
               const scale = UI_SIZE_SCALE[settings.uiSize];
+              const nextWidth = Math.min(
+                POPUP_MAX_WIDTH,
+                Math.max(POPUP_MIN_WIDTH, Math.round(payload.width / nativeScale / scale)),
+              );
               const nextHeight = Math.min(
                 POPUP_MAX_HEIGHT,
                 Math.max(
@@ -137,15 +143,15 @@ export function useAppearance() {
                   Math.round(payload.height / nativeScale / scale),
                 ),
               );
-              if (nextHeight === settings.popupHeight) return;
+              if (nextWidth === settings.popupWidth && nextHeight === settings.popupHeight) return;
 
-              currentSettings = { ...settings, popupHeight: nextHeight };
-              pendingHeight = nextHeight;
+              pendingSize = { popupWidth: nextWidth, popupHeight: nextHeight };
+              currentSettings = { ...settings, ...pendingSize };
               if (resizeTimer) clearTimeout(resizeTimer);
               resizeTimer = setTimeout(() => {
-                const height = pendingHeight!;
-                pendingHeight = null;
-                void patchSettings({ popupHeight: height }).catch(() => {});
+                const size = pendingSize!;
+                pendingSize = null;
+                void patchSettings(size).catch(() => {});
               }, 250);
             }),
           )

--- a/src/settings/service.test.ts
+++ b/src/settings/service.test.ts
@@ -38,6 +38,10 @@ describe("settings schema defaults", () => {
       new Set(Object.keys(defaultSettings)),
     );
   });
+  it("supplies a width for legacy settings and bounds narrow stored widths", () => {
+    expect(mergeSettings({}).popupWidth).toBe(360);
+    expect(mergeSettings({ popupWidth: 250 }).popupWidth).toBe(300);
+  });
   it("deep-merges partial nested settings without mutating defaults", () => {
     const merged = mergeSettings({
       trayColors: { running: "#123456" } as typeof defaultSettings.trayColors,
@@ -100,6 +104,7 @@ describe("settings schema defaults", () => {
       idleThresholdMinutes: -20,
       noTimerReminderMinutes: 2000,
       popupMonitorIndex: 999,
+      popupWidth: 9999,
       popupHeight: 9999,
       popupLayout: "unknown",
       enableIdleDetection: "true",
@@ -114,6 +119,7 @@ describe("settings schema defaults", () => {
     expect(merged.idleThresholdMinutes).toBe(1);
     expect(merged.noTimerReminderMinutes).toBe(1440);
     expect(merged.popupMonitorIndex).toBe(255);
+    expect(merged.popupWidth).toBe(1000);
     expect(merged.popupHeight).toBe(1200);
     expect(merged.popupLayout).toBe(defaultSettings.popupLayout);
     expect(merged.enableIdleDetection).toBe(defaultSettings.enableIdleDetection);

--- a/src/settings/service.ts
+++ b/src/settings/service.ts
@@ -71,6 +71,7 @@ export const defaultSettings: AppSettings = {
 
   theme: "light",
   uiSize: "default",
+  popupWidth: 360,
   popupHeight: 640,
   roundedPopupCorners: true,
   reduceVisualEffects: false,
@@ -471,6 +472,7 @@ export function mergeSettings(raw?: Partial<AppSettings> | null): AppSettings {
       ["small", "default", "large", "scale130", "scale145", "scale160"] as const,
       defaultSettings.uiSize,
     ),
+    popupWidth: integerValue(value.popupWidth, defaultSettings.popupWidth, 300, 1000),
     popupHeight: integerValue(
       value.popupHeight,
       defaultSettings.popupHeight,

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,8 @@ export interface AppSettings {
 
   theme: "light" | "dark" | "transparent";
   uiSize: "small" | "default" | "large" | "scale130" | "scale145" | "scale160";
+  /** Base tray popup width in logical pixels, before UI scaling. */
+  popupWidth: number;
   /** Base tray popup height in logical pixels, before UI scaling. */
   popupHeight: number;
   roundedPopupCorners: boolean;


### PR DESCRIPTION
## Summary
I came across some bugs:
- On both **Windows 11** and **Kubuntu 26.04**, clicking on the border of the tray popup caused it to close immediately. It was not possible to resize the popup at all.
- Furthermore, the width of the popup is currently fixed. While this seems to be a deliberate design choice, in my case it resulted in many lines of text being truncated, making the content of the popup tray partially unreadable.
  Therefore, I would argue that users should be allowed to decide whether or not to change the width of the popup :)

## Fixes
- Add shared dismissal handling with native focus, mouse-button and resize-state checks for Linux, Windows and macOS.
- Keep the popup open during resizing while preserving normal click-away dismissal.
- Add the missing scale-factor permission required for resize tracking.
- Persist width and height with UI scaling and validated size limits.
- Add regression coverage for resize/focus decisions and dimension persistence.

## Tests
```bash
cargo fmt --check
cargo check --locked
cargo test --locked
cargo clippy --locked --all-targets -- -D warnings
```
- Tested on **Kubuntu** & **Windows**
- _NOT_ tested on macOS, as I don't have & use this OS

## Screenshots:
- Windows:
  <img width="1030" height="545" alt="Screenshot_20260909_044816" src="https://github.com/user-attachments/assets/99eb508e-c93c-4219-a9fb-42036097c9f0" />
  <img width="1364" height="542" alt="Screenshot_20260909_045649" src="https://github.com/user-attachments/assets/853d3cb6-79ec-4cce-8b91-9384e1231f09" />

- Linux:
  <img width="980" height="908" alt="image" src="https://github.com/user-attachments/assets/da467509-cc98-41ce-a176-e092baa4fff3" />
  <img width="1298" height="909" alt="image" src="https://github.com/user-attachments/assets/4dee21de-16cf-42d4-9fde-80ba0a337bea" />

## LLM disclosure
Developed with assistance from GPT- 6 Astra (Extra High). The LLM helped me identify the related files, code parts and proposed possible fixes.
I've manually reviewed the code the best I could, but since my coding capabilities are not that good yet, proper code review is required in any case.